### PR TITLE
Don't publish to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/eslint-config-appeals",
   "version": "1.0.2",
+  "private": true,
   "description": "ESLint config for Appeals JS.",
   "main": ".eslintrc.js",
   "repository": "https://github.com/department-of-veterans-affairs/eslint-config-appeals.git",


### PR DESCRIPTION
After https://github.com/department-of-veterans-affairs/caseflow-efolder/pull/1027 we no longer need to publish this to NPM. We can prevent this package from being published again using [private](https://docs.npmjs.com/misc/registry#i-dont-want-my-package-published-in-the-official-registry-its-private).